### PR TITLE
Fixed maxW selection in createDynamicWindow by changing max() to min()

### DIFF
--- a/src/dwa.c
+++ b/src/dwa.c
@@ -9,7 +9,7 @@ createDynamicWindow(Velocity velocity, Config config, DynamicWindow **dynamicWin
   float minW =
     max(-config.maxYawrate, velocity.angularVelocity - config.maxdYawrate * config.dt);
   float maxW =
-    max(config.maxYawrate, velocity.angularVelocity + config.maxdYawrate * config.dt);
+    min(config.maxYawrate, velocity.angularVelocity + config.maxdYawrate * config.dt);
 
   int nPossibleV = (maxV - minV) / config.velocityResolution;
   int nPossibleW = (maxW - minW) / config.yawrateResolution;


### PR DESCRIPTION
Possible angular velocities were tilted towards positive values